### PR TITLE
fix: use string type, replace commas

### DIFF
--- a/src/Components/Pages/FormikContextElements/Fees.tsx
+++ b/src/Components/Pages/FormikContextElements/Fees.tsx
@@ -35,8 +35,11 @@ const FeesFormikWrapped: React.FC<IFeesFormikWrapped> = ({
           <Typography component="p">Transfer Amount:</Typography>
           <Typography component="p">
             {Number(
-              (values as Record<string, string | number>)[amountFormikName],
-            )?.toFixed(3)}{' '}
+              (values as Record<string, string>)[amountFormikName].replaceAll(
+                ',',
+                '',
+              ),
+            ).toLocaleString('en-US')}{' '}
             {symbol}
           </Typography>
         </>

--- a/src/Components/Pages/TransferPage.tsx
+++ b/src/Components/Pages/TransferPage.tsx
@@ -204,7 +204,7 @@ const useStyles = makeStyles(({ constants, palette }: ITheme) =>
 );
 
 type PreflightDetails = {
-  tokenAmount: number;
+  tokenAmount: string;
   token: string;
   tokenSymbol: string;
   receiver: string;
@@ -239,7 +239,7 @@ const TransferPage = (): JSX.Element => {
     token:
       homeConfig?.type === 'Ethereum' ? homeConfig.tokens[0].address : 'CFG',
     tokenSymbol: homeConfig?.nativeTokenSymbol || '',
-    tokenAmount: 0,
+    tokenAmount: '0',
   });
 
   useEffect(() => {
@@ -422,7 +422,7 @@ const TransferPage = (): JSX.Element => {
         )}
       <Formik
         initialValues={{
-          tokenAmount: 0,
+          tokenAmount: '0',
           token:
             homeConfig?.type === 'Ethereum'
               ? homeConfig.tokens[0].address
@@ -520,7 +520,7 @@ const TransferPage = (): JSX.Element => {
           setPreflightModalOpen(false);
           preflightDetails &&
             deposit(
-              preflightDetails.tokenAmount,
+              parseFloat(preflightDetails.tokenAmount.replaceAll(',', '')),
               preflightDetails.receiver,
               preflightDetails.token,
             );
@@ -528,7 +528,9 @@ const TransferPage = (): JSX.Element => {
         sourceNetwork={homeConfig?.name || ''}
         targetNetwork={destinationChainConfig?.name || ''}
         tokenSymbol={preflightDetails?.tokenSymbol || ''}
-        value={preflightDetails?.tokenAmount || 0}
+        value={
+          parseFloat(preflightDetails?.tokenAmount.replaceAll(',', '')) || 0
+        }
       />
       <TransferActiveModal open={!!transactionStatus} close={resetDeposit} />
       {/* This is here due to requiring router */}


### PR DESCRIPTION
### Description

This pull request changes the type of `tokenAmount` from `number` to `string` and where necessary replaces the commas with whitespace.