### PR TITLE
chore: change wcfg wording

### DIFF
--- a/src/Components/Pages/TransferPage.tsx
+++ b/src/Components/Pages/TransferPage.tsx
@@ -40,9 +40,7 @@ const useStyles = makeStyles(({ constants, palette }: ITheme) =>
       marginBottom: '28px',
     },
     connectButton: {
-      width: '160px',
       fontSize: '16px',
-      height: '40px',
     },
     connecting: {
       textAlign: 'center',
@@ -350,6 +348,7 @@ const TransferPage = (): JSX.Element => {
             width: '100%',
             display: 'flex',
             justifyContent: 'space-between',
+            gap: 16,
           }}
         >
           <Button
@@ -359,7 +358,7 @@ const TransferPage = (): JSX.Element => {
               setWalletType('Ethereum');
             }}
           >
-            Get CFG
+            Transfer CFG from Ethereum to Centrifuge
           </Button>
           <Button
             className={classes.connectButton}
@@ -368,7 +367,7 @@ const TransferPage = (): JSX.Element => {
               setWalletType('Substrate');
             }}
           >
-            Get wCFG
+            Transfer CFG from Centrifuge to Ethereum
           </Button>
         </div>
       );

--- a/src/Layouts/AppWrapper.tsx
+++ b/src/Layouts/AppWrapper.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles(({ animation, constants, palette }: ITheme) =>
       // left: "50%",
       margin: '0 auto',
       // transform: "translate(-50%, -50%)",
-      maxWidth: 460,
+      maxWidth: 540,
       display: 'flex',
       flexDirection: 'column',
       overflow: 'hidden',

--- a/src/Modules/TransferActiveModal.tsx
+++ b/src/Modules/TransferActiveModal.tsx
@@ -164,7 +164,6 @@ const TransferActiveModal: React.FC<ITransferActiveModalProps> = ({
     depositAmount,
     transferTxHash,
   } = useChainbridge();
-  const tokenSymbol = homeConfig?.type === 'Ethereum' ? 'wCFG' : 'CFG';
 
   return (
     <CustomModal
@@ -245,7 +244,7 @@ const TransferActiveModal: React.FC<ITransferActiveModalProps> = ({
             <Typography className={classes.receipt} component="p">
               Successfully transferred{' '}
               <strong>
-                {depositAmount} {tokenSymbol}
+                {depositAmount} CFG
                 <br /> from {homeConfig?.name} to {destinationChainConfig?.name}
                 .
               </strong>


### PR DESCRIPTION
### Description

This pull request removes the usage of `wCFG` in the chainbridge UI.

<img width="709" alt="image" src="https://github.com/centrifuge/chainbridge-ui/assets/28536523/d55fea06-efb5-450d-a56b-d373101a0680">

Closes https://github.com/centrifuge/apps/issues/1968
